### PR TITLE
Avoid name clashing with phantomjs.rb

### DIFF
--- a/bin/phantomjs
+++ b/bin/phantomjs
@@ -8,6 +8,6 @@ require "phantomjs-binaries/version"
 
 machine  = Uname.machine
 platform = Uname.sysname.downcase
-version  = Phantomjs::Binaries::PHANTOM_VERSION
+version  = PhantomjsBinaries::PHANTOM_VERSION
 platform_binary = File.expand_path(File.join(File.dirname(__FILE__), "phantomjs-#{version}-#{platform}-#{machine}"))
 exec platform_binary, *ARGV

--- a/lib/phantomjs-binaries.rb
+++ b/lib/phantomjs-binaries.rb
@@ -1,7 +1,4 @@
 require "phantomjs-binaries/version"
 
-module Phantomjs
-  module Binaries
-    # Your code goes here...
-  end
+module PhantomjsBinaries
 end

--- a/lib/phantomjs-binaries/version.rb
+++ b/lib/phantomjs-binaries/version.rb
@@ -1,6 +1,4 @@
-module Phantomjs
-  module Binaries
-    PHANTOM_VERSION = "2.1.1"
-    VERSION = PHANTOM_VERSION + ".0"
-  end
+module PhantomjsBinaries
+  PHANTOM_VERSION = "2.1.1"
+  VERSION = PHANTOM_VERSION + ".0"
 end

--- a/phantomjs-binaries.gemspec
+++ b/phantomjs-binaries.gemspec
@@ -4,7 +4,7 @@ require "phantomjs-binaries/version"
 
 Gem::Specification.new do |s|
   s.name        = "phantomjs-binaries"
-  s.version     = Phantomjs::Binaries::VERSION
+  s.version     = PhantomjsBinaries::VERSION
   s.authors     = ["Anton Vaynshtok"]
   s.email       = ["avaynshtok@gmail.com"]
   s.homepage    = "https://github.com/avaynshtok/phantomjs-binaries"


### PR DESCRIPTION
When have both this and https://github.com/westoque/phantomjs.rb in Gemfile, the following happens:

```
Gem Load Error is: Phantomjs is not a class
Backtrace for gem load error is:
.../gems/phantomjs.rb-2.1.0/lib/phantomjs/configuration.rb:1:in `<top (required)>'
```
